### PR TITLE
LXC network fixes

### DIFF
--- a/tasks/lxc_install.yml
+++ b/tasks/lxc_install.yml
@@ -39,6 +39,10 @@
 # Mount cgroup+fstab
 - mount: src=cgroup name='/sys/fs/cgroup' opts=defaults fstype=cgroup state=mounted
 
+# Create interfaces.d
+- name: create interfaces.d if not exist
+  file: path=/etc/network/interfaces.d/ owner=root group=root mode=0755 state=directory
+
 # network interface
 - name: configure network interfaces (NAT mode)
   template: src=interfaces_nat.j2 dest=/etc/network/interfaces.d/lxc
@@ -48,10 +52,6 @@
 - name: configure network interfaces (BRIDGE mode)
   template: src=interfaces_bridge.j2 dest=/etc/network/interfaces backup=yes
   when: lxc_network_mode == 'bridge'
-
-# Create interfaces.d
-- name: create interfaces.d if not exist
-  file: path=/etc/network/interfaces.d/ owner=root group=root mode=0755 state=directory
 
 # Dnsmasq
 - name: configure dnsmasq

--- a/tasks/lxc_install.yml
+++ b/tasks/lxc_install.yml
@@ -69,6 +69,9 @@
 - name: add network template
   template: src=lxc-template.conf.j2 dest=/etc/lxc/lxc-template.conf owner=root group=root mode=0644
 
+- name: Start lxcbr0
+  shell: ifup lxcbr0
+
 # Add lxc-convert
 - copy: src=lxc-convert dest=/usr/bin/lxc-convert owner=root group=root mode=0755
 

--- a/tasks/lxc_install.yml
+++ b/tasks/lxc_install.yml
@@ -41,7 +41,7 @@
 
 # network interface
 - name: configure network interfaces (NAT mode)
-  template: src=interfaces_nat.j2 dest=/etc/network/interfaces.d/lxc backup=yes
+  template: src=interfaces_nat.j2 dest=/etc/network/interfaces.d/lxc
   when: lxc_network_mode == 'nat'
 
 # network interface


### PR DESCRIPTION
Hi,

This PR fill some miss in net iface management :
- a interface.d/lxc.YYY... backup is created. But this file is loaded too by ifupdown. This lead to duplicated bridge definition and ifup fails with "already configured"
- interface.d directory was created after the lxc file was rendered in.
- lxcbr0 is not started after setup.
