### PR TITLE
Let ifupdown managerbridge creation/destruction

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,7 @@ lxc_dhcp_leasefile: /var/lib/misc/dnsmasq.lxcbr0.leases
 lxc_network_mode: bridge
 # Whether to start and stop dnsmasq with iface
 lxc_tight_dedicated_dnsmasq: true
+# bridge IP (NAT mode)
+lxcbr0_ip: 192.168.0.1
+# bridge netmask (NAT mode)
+lxcbr0_netmask: 255.255.255.0

--- a/templates/dnsmasq.conf.j2
+++ b/templates/dnsmasq.conf.j2
@@ -7,6 +7,7 @@ bind-interfaces
 #dhcp-fqdn
 # Domain name and ip range with lease time
 domain={{ lxc_domain }},{{ lxc_ipnet }}
+local=/{{ lxc_domain }}/
 dhcp-range={{ lxc_dhcp_range }}
 dhcp-leasefile={{ lxc_dhcp_leasefile }}
 # DHCP options

--- a/templates/interfaces_nat.j2
+++ b/templates/interfaces_nat.j2
@@ -2,9 +2,9 @@
 
 auto lxcbr0
 iface lxcbr0 inet static
-    pre-up brctl addbr lxcbr0
     bridge_fd 0
     bridge_maxwait 0
+    bridge_ports none
     address {{ lxcbr0_ip }}
     netmask {{ lxcbr0_netmask }}
     post-up iptables -A FORWARD -i lxcbr0 -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j ACCEPT

--- a/templates/interfaces_nat.j2
+++ b/templates/interfaces_nat.j2
@@ -7,12 +7,15 @@ iface lxcbr0 inet static
     bridge_ports none
     address {{ lxcbr0_ip }}
     netmask {{ lxcbr0_netmask }}
-    post-up iptables -A FORWARD -i lxcbr0 -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j ACCEPT
-    post-up iptables -A POSTROUTING -t nat -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j MASQUERADE
+    post-up   iptables -A FORWARD -i $IFACE -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j ACCEPT
+    post-down iptables -D FORWARD -i $IFACE -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j ACCEPT || true
+    post-up   iptables -A POSTROUTING -t nat -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j MASQUERADE
+    post-down iptables -D POSTROUTING -t nat -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j MASQUERADE || treu
     # add checksum so that dhclient does not complain.
     # udp packets staying on the same host never have a checksum filled else
-    post-up iptables -A POSTROUTING -t mangle -p udp --dport bootpc -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j CHECKSUM --checksum-fill
+    post-up   iptables -A POSTROUTING -t mangle -p udp --dport bootpc -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j CHECKSUM --checksum-fill
+    post-down iptables -D POSTROUTING -t mangle -p udp --dport bootpc -s {{ lxcbr0_ip }}/{{ lxcbr0_netmask }} -j CHECKSUM --checksum-fill || true
     {% if lxc_tight_dedicated_dnsmasq %}
-    post-up dnsmasq --pid-file=/var/run/lxc-dnsmasq.$IFACE.pid --conf-file=/etc/dnsmasq.$IFACE.conf
+    post-up   dnsmasq --pid-file=/var/run/lxc-dnsmasq.$IFACE.pid --conf-file=/etc/dnsmasq.$IFACE.conf
     post-down kill $(cat /var/run/lxc-dnsmasq.$IFACE.pid) || true
     {% endif %}


### PR DESCRIPTION
Without this, ifdown does not destroy lxcbr0. Which make it inconsistend for following ifup.
