### PR TITLE
Supports lxc-net native service

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ them are as follows.
     # The DHCP range served by dnsmasq with the lease time
     lxc_dhcp_range: 192.168.0.50,192.168.0.200,1h
     # Set network mode: nat or bridge
-    lxc_network_mode: bridge
+    lxc_network_mode: lxc-net
 ```
 
 You can also set specific parameters depending the host configuration you want
@@ -34,7 +34,7 @@ to give. Here is an example
 ```
 [servers]
 bridge.server.lan lxcbr0_ip=10.0.0.1 lxc_ipnet=10.0.0.0/24 lxc_dhcp_range=10.0.0.200,10.0.0.220,1h lxc_network_mode=bridge
-nat.server.lan lxcbr0_ip=192.168.0.1 lxc_ipnet=192.168.0.0/24 lxc_dhcp_range=192.168.0.200,192.168.0.220,1h lxc_network_mode=nat
+nat.server.lan lxcbr0_ip=192.168.0.1 lxc_ipnet=192.168.0.0/24 lxc_dhcp_range=192.168.0.200,192.168.0.220,1h lxc_network_mode=lxc-net
 ```
 
 Examples
@@ -51,12 +51,12 @@ Examples
 
   vars:
     - lxc_template_path: /tmp/lxc-debian-wheezy-template
-    - lxc_domain: mydomain.lan
+    - lxc_domain: lxc
     - lxc_ipnet: 192.168.0.0/24
     - lxc_dhcp_range: 192.168.0.50,192.168.0.200,1h
     - lxcbr0_ip: 192.168.0.1
     - lxcbr0_netmask: 255.255.255.0
-    - lxc_network_mode: nat
+    - lxc_network_mode: lxc-net
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ lxc_ipnet: 192.168.0.0/24
 lxc_dhcp_range: 192.168.0.50,192.168.0.200,1h
 # The lease file for dnsmasq
 lxc_dhcp_leasefile: /var/lib/misc/dnsmasq.lxcbr0.leases
-# Set network mode: nat or bridge
+# Set network mode: nat or bridge or lxc-net
 lxc_network_mode: bridge
 # Whether to start and stop dnsmasq with iface
 lxc_tight_dedicated_dnsmasq: true

--- a/tasks/lxc_install.yml
+++ b/tasks/lxc_install.yml
@@ -48,6 +48,12 @@
   template: src=interfaces_bridge.j2 dest=/etc/network/interfaces backup=yes
   when: lxc_network_mode == 'bridge'
 
+- name: configure lxc-net
+  template:
+    src: lxc-net.j2
+    dest: /etc/default/lxc-net
+  register: lxc_net
+
 - name: configure dnsmasq
   template: src=dnsmasq.lxc.conf.j2 dest=/etc/dnsmasq.d/lxc.conf owner=root group=root mode=0644
   register: dnsmasq
@@ -58,12 +64,20 @@
 
 - name: configure lxcbr0 dnsmasq
   template: src=dnsmasq.conf.j2 dest=/etc/dnsmasq.lxcbr0.conf owner=root group=root mode=0644
+  when: lxc_tight_dedicated_dnsmasq
 
 - name: add LXC template with network
   template: src=lxc-template.conf.j2 dest=/etc/lxc/lxc-template.conf owner=root group=root mode=0644
 
 - name: start lxcbr0
+  when: lxc_network_mode in ('nat', 'bridge')
   shell: ifup lxcbr0
+
+- name: start lxc-net
+  when: lxc_net|changed
+  service:
+    name: lxc-net
+    state: restarted
 
 - name: add lxc-convert
   copy: src=lxc-convert dest=/usr/bin/lxc-convert owner=root group=root mode=0755

--- a/templates/lxc-net.j2
+++ b/templates/lxc-net.j2
@@ -1,0 +1,8 @@
+USE_LXC_BRIDGE="true"
+LXC_BRIDGE="lxcbr0"
+LXC_ADDR="{{ lxcbr0_ip }}"
+LXC_NETMASK="{{ lxcbr0_netmask }}"
+LXC_NETWORK="{{ lxc_ipnet }}"
+LXC_DHCP_RANGE="{{ lxc_dhcp_range }}"
+LXC_DHCP_CONFILE=""
+LXC_DOMAIN="{{ lxc_domain }}"


### PR DESCRIPTION
Hi,

lxc now ships lxc-net which takes care of managing interface and dnsmasq. Let's support this in this role :)

This PR adds a new network mode : `lxc-net`. In this mode, we only take care of `/etc/default/lxc-net` configuration and ensure `lxc-net` service is started.